### PR TITLE
Fix clicked state reset on mouse release

### DIFF
--- a/packages/dom/src/Document.ts
+++ b/packages/dom/src/Document.ts
@@ -199,6 +199,7 @@ export class Document {
         x: event.x,
         y: event.y,
       });
+      this.state.clicked = null;
       return;
     }
     const hovered = this.renderer.getNodeAt(


### PR DESCRIPTION
## Summary
- ensure Document resets clicked state after mouse release

## Testing
- `pnpm exec vitest run` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.3.0.tgz)*