### PR TITLE
Fix selection extend across nodes

### DIFF
--- a/packages/dom/src/Selection.ts
+++ b/packages/dom/src/Selection.ts
@@ -55,7 +55,9 @@ export class Selection {
       SelectionExtendGranularity[granularity] ?? raise("Invalid granularity"),
       SelectionExtendDirection[direction] ?? raise("Invalid direction"),
       this.ghostPosition ?? undefined,
-      rootNodeId ?? undefined
+      // Default to the tree root when no specific node is provided so
+      // selection extension can cross node boundaries.
+      rootNodeId ?? 0
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure `Selection.extendBy` defaults to the tree root when no node is given

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*