### PR TITLE
Fix selection extend across nodes

### DIFF
--- a/packages/core/src/layout/tree/Selection.zig
+++ b/packages/core/src/layout/tree/Selection.zig
@@ -145,7 +145,10 @@ pub fn findLineBox(tree: *Tree, focus: BoundaryPoint) ?struct {
 
     for (computed_style.lines.items, 0..) |line, i| {
         for (line.parts.items, 0..) |part, j| {
-            if (part.node_id == focus.node_id and focus.offset >= part.node_offset and focus.offset < part.node_offset + part.length) {
+            if (part.node_id == focus.node_id and
+                focus.offset >= part.node_offset and
+                focus.offset <= part.node_offset + part.length)
+            {
                 return .{ .line_index = i, .part_index = j, .root_node_id = root_node_id };
             }
         }

--- a/packages/dom/src/Selection.ts
+++ b/packages/dom/src/Selection.ts
@@ -55,7 +55,9 @@ export class Selection {
       SelectionExtendGranularity[granularity] ?? raise("Invalid granularity"),
       SelectionExtendDirection[direction] ?? raise("Invalid direction"),
       this.ghostPosition ?? undefined,
-      rootNodeId ?? undefined
+      // Default to the tree root when no specific node is provided so
+      // selection extension can cross node boundaries.
+      rootNodeId ?? 0
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure `Selection.extendBy` defaults to the tree root when no node is given
- handle end-of-node offsets when locating line boxes

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.