### PR TITLE
Fix selection extend across nodes

### DIFF
--- a/packages/core/src/layout/tree/Selection.zig
+++ b/packages/core/src/layout/tree/Selection.zig
@@ -387,8 +387,11 @@ pub fn getBoundaryAt(
                     line_box_indexes.part_index,
                     root_node_id,
                 ) orelse return null;
+
+                const part_root = findLineBoxAncestor(tree, target_part.node_id);
+                const part_ct = tree.getComputedText(part_root) orelse return null;
                 var grapheme_iter = GraphemeIterator.init(
-                    computed_text.slice(
+                    part_ct.slice(
                         target_part.node_offset,
                         target_part.node_offset + target_part.length,
                     ),
@@ -412,8 +415,11 @@ pub fn getBoundaryAt(
                     line_box_indexes.part_index,
                     root_node_id,
                 ) orelse return null;
+
+                const part_root = findLineBoxAncestor(tree, target_part.node_id);
+                const part_ct = tree.getComputedText(part_root) orelse return null;
                 var grapheme_iter = GraphemeIterator.init(
-                    computed_text.slice(
+                    part_ct.slice(
                         target_part.node_offset,
                         target_part.node_offset + target_part.length,
                     ),

--- a/packages/dom/src/Selection.ts
+++ b/packages/dom/src/Selection.ts
@@ -55,7 +55,9 @@ export class Selection {
       SelectionExtendGranularity[granularity] ?? raise("Invalid granularity"),
       SelectionExtendDirection[direction] ?? raise("Invalid direction"),
       this.ghostPosition ?? undefined,
-      rootNodeId ?? undefined
+      // Default to the tree root when no specific node is provided so
+      // selection extension can cross node boundaries.
+      rootNodeId ?? 0
     );
   }
 }


### PR DESCRIPTION
## Summary
- ensure `Selection.extendBy` defaults to the tree root when no node is given
- fix computed text lookup when moving by character across node boundaries

## Testing
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*
