### PR TITLE
Improve vertical selection offsets

### DIFF
--- a/packages/core/js/exportsSchema.ts
+++ b/packages/core/js/exportsSchema.ts
@@ -508,6 +508,13 @@ export const getSchema = (
       catchError("Selection_extendBy"),
     ),
 
+    Selection_getHorizontalOffset: pipe(
+      function_(),
+      args(tuple([number(), number(), number()])),
+      returns(number()),
+      catchError("Selection_getHorizontalOffset"),
+    ),
+
     Renderer_init: pipe(
       function_(),
       args(tuple([])),

--- a/packages/core/src/layout/tree/Selection.zig
+++ b/packages/core/src/layout/tree/Selection.zig
@@ -319,6 +319,24 @@ fn getPreviousLineBoxPart(
     return null;
 }
 
+pub fn getHorizontalOffset(
+    tree: *Tree,
+    bp: BoundaryPoint,
+) ?f32 {
+    const indexes = findLineBox(tree, bp) orelse return null;
+    const computed_text = tree.getComputedText(indexes.root_node_id) orelse return null;
+    const line = computed_text.lines.items[indexes.line_index];
+    const part = line.parts.items[indexes.part_index];
+    var pos = line.position.x;
+    for (line.parts.items, 0..) |current, i| {
+        if (i == indexes.part_index) break;
+        pos += current.size.x;
+    }
+    const slice = computed_text.slice(part.node_offset, bp.offset);
+    pos += @floatFromInt(measureText(slice));
+    return pos;
+}
+
 pub fn getBoundaryAt(
     tree: *Tree,
     focus: BoundaryPoint,
@@ -449,17 +467,8 @@ pub fn getBoundaryAt(
         return BoundaryPoint{ .node_id = first_part.node_id, .offset = @intCast(first_part.node_offset) };
     }
     if (granularity == .line) {
-        var offset_horizontal_position = line.position.x;
-        if (ghost_horizontal_position) |pos| {
-            offset_horizontal_position = pos;
-        } else {
-            for (line.parts.items, 0..) |current, i| {
-                if (i == line_box_indexes.part_index) break;
-                offset_horizontal_position += current.size.x;
-            }
-            const part_slice = computed_text.slice(part.node_offset, focus.offset);
-            offset_horizontal_position += @floatFromInt(measureText(part_slice));
-        }
+        const offset_horizontal_position = ghost_horizontal_position orelse
+            (getHorizontalOffset(tree, focus) orelse line.position.x);
 
         // const maybe_target_line = findInlineLineBox(tree, focus.node_id, root_node_id, direction);
         const maybe_target_line = switch (direction) {

--- a/packages/core/src/wasm.zig
+++ b/packages/core/src/wasm.zig
@@ -435,6 +435,15 @@ export fn Selection_extendBy(
     ));
 }
 
+export fn Selection_getHorizontalOffset(
+    tree: *Tree,
+    node_id: u32,
+    offset: u32,
+) f32 {
+    const bp = BoundaryPoint{ .node_id = node_id, .offset = offset };
+    return Tree.Selection.getHorizontalOffset(tree, bp) orelse 0;
+}
+
 export fn Renderer_renderToStdout(renderer: *Renderer, tree: *Tree, clear_screen: bool) void {
     logger.info("Renderer_renderToStdout({*}, {*}, {any})", .{ renderer, tree, clear_screen });
     wasm_try(void, renderer.render(wasm_allocator, tree, std.io.getStdOut().writer().any(), clear_screen));

--- a/packages/dom/src/Selection.ts
+++ b/packages/dom/src/Selection.ts
@@ -28,6 +28,7 @@ export class Selection {
     );
   }
   setAnchor(node: number, offset: number) {
+    this.ghostPosition = null;
     return this.document.module.Selection_setAnchor(
       this.document.tree.ptr,
       this.id,
@@ -36,6 +37,7 @@ export class Selection {
     );
   }
   setFocus(node: number, offset: number) {
+    this.ghostPosition = null;
     return this.document.module.Selection_setFocus(
       this.document.tree.ptr,
       this.id,
@@ -49,13 +51,28 @@ export class Selection {
     direction: keyof typeof SelectionExtendDirection,
     rootNodeId?: number,
   ) {
+    if (granularity === "line") {
+      if (this.ghostPosition === null) {
+        const focus = this.getFocus();
+        this.ghostPosition =
+          this.document.module.Selection_getHorizontalOffset(
+            this.document.tree.ptr,
+            focus.node,
+            focus.offset,
+          );
+      }
+    } else {
+      this.ghostPosition = null;
+    }
     return this.document.module.Selection_extendBy(
       this.document.tree.ptr,
       this.id,
       SelectionExtendGranularity[granularity] ?? raise("Invalid granularity"),
       SelectionExtendDirection[direction] ?? raise("Invalid direction"),
       this.ghostPosition ?? undefined,
-      rootNodeId ?? undefined
+      // Default to the tree root when no specific node is provided so
+      // selection extension can cross node boundaries.
+      rootNodeId ?? 0
     );
   }
 }


### PR DESCRIPTION
## Summary
- expose `Selection_getHorizontalOffset` from the core
- calculate ghost horizontal position using new API
- factor out horizontal position logic on the Zig side

## Testing
- `npx biome check packages/dom/src/Selection.ts` *(fails: connect EHOSTUNREACH)*
- `pnpm lint` *(fails: connect EHOSTUNREACH)*
- `pnpm test` *(fails: connect EHOSTUNREACH)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.