### PR TITLE
Refactor layout code organization

### DIFF
--- a/packages/core/src/layout/compute/compute_alignment_offset.zig
+++ b/packages/core/src/layout/compute/compute_alignment_offset.zig
@@ -7,7 +7,7 @@ const AlignContent = @import("../tree/Style.zig").AlignContent;
 ///   - For both the Flexbox and CSS Grid algorithms
 /// CSS Grid does not apply gaps as part of alignment, so the gap parameter should
 /// always be set to zero for CSS Grid.
-pub fn compute_alignment_offset(
+pub fn computeAlignmentOffset(
     free_space: f32,
     num_items: usize,
     gap: f32,
@@ -60,7 +60,7 @@ pub fn compute_alignment_offset(
         }
     }
 }
-// pub(crate) fn compute_alignment_offset(
+// pub(crate) fn computeAlignmentOffset(
 //     free_space: f32,
 //     num_items: usize,
 //     gap: f32,

--- a/packages/core/src/layout/compute/compute_block_layout.zig
+++ b/packages/core/src/layout/compute/compute_block_layout.zig
@@ -20,8 +20,8 @@ const SizingMode = @import("compute_constants.zig").SizingMode;
 const CollapsibleMarginSet = @import("compute_constants.zig").CollapsibleMarginSet;
 const styles = @import("../../styles/styles.zig");
 const with = @import("../utils/comptime.zig").with;
-const perform_child_layout = @import("perform_child_layout.zig").perform_child_layout;
-const compute_content_size_contribution = @import("compute_content_size_contribution.zig").compute_content_size_contribution;
+const performChildLayout = @import("perform_child_layout.zig").performChildLayout;
+const computeContentSizeContribution = @import("compute_content_size_contribution.zig").computeContentSizeContribution;
 const ItemKind = union(enum) {
     block: Node.NodeId,
     inline_stream: Array(Node.NodeId),
@@ -249,7 +249,7 @@ fn computeInner(allocator: std.mem.Allocator, node_id: Node.NodeId, tree: *Tree,
                 .order = @intCast(order),
                 .margin = .{ .top = 0, .right = 0, .bottom = 0, .left = 0 },
             });
-            _ = try perform_child_layout(
+            _ = try performChildLayout(
                 allocator,
                 child_id,
                 tree,
@@ -400,7 +400,7 @@ pub fn determineContentBasedContainerWidth(
             const item_x_margin_sum: f32 = item.margin.maybeResolve(available_space_width).orZero().sumHorizontal();
             // switch (item.nodes) {
             //     .block => |child| {
-            const size_and_baselines = try perform_child_layout(
+            const size_and_baselines = try performChildLayout(
                 allocator,
                 item.node_id,
                 tree,
@@ -499,7 +499,7 @@ fn performFinalLayoutOnInFlowChildren(
             .y = available_space.y,
         };
 
-        const item_layout = try perform_child_layout(
+        const item_layout = try performChildLayout(
             allocator,
             item.node_id,
             tree,
@@ -510,7 +510,7 @@ fn performFinalLayoutOnInFlowChildren(
             .{ .start = true, .end = true },
         );
         // const item_layout = switch (item.nodes) {
-        //     .block => |child| try perform_child_layout(
+        //     .block => |child| try performChildLayout(
         //         allocator,
         //         child,
         //         tree,
@@ -612,7 +612,7 @@ fn performFinalLayoutOnInFlowChildren(
 
         tree.setUnroundedLayout(item.node_id, layout);
 
-        inflow_content_size = inflow_content_size.max(compute_content_size_contribution(
+        inflow_content_size = inflow_content_size.max(computeContentSizeContribution(
             location,
             final_size,
             item_layout.content_size,
@@ -714,7 +714,7 @@ pub fn performAbsoluteLayoutOnAbsoluteChildren(
             known_dimensions = known_dimensions.maybeApplyAspectRatio(aspect_ratio).maybeClamp(min_size, max_size);
         };
 
-        const layout_output = try perform_child_layout(
+        const layout_output = try performChildLayout(
             allocator,
             child_id,
             tree,
@@ -835,7 +835,7 @@ pub fn performAbsoluteLayoutOnAbsoluteChildren(
             .margin = resolved_margin,
         });
 
-        absolute_content_size = absolute_content_size.max(compute_content_size_contribution(
+        absolute_content_size = absolute_content_size.max(computeContentSizeContribution(
             location,
             final_size,
             layout_output.content_size,

--- a/packages/core/src/layout/compute/compute_child_layout.zig
+++ b/packages/core/src/layout/compute/compute_child_layout.zig
@@ -9,11 +9,11 @@ const compute_constants = @import("compute_constants.zig");
 const AvailableSpace = compute_constants.AvailableSpace;
 const SizingMode = compute_constants.SizingMode;
 
-const compute_flexbox_layout = @import("compute_flexbox_layout.zig").compute_flexbox_layout;
-const compute_leaf_layout = @import("compute_leaf_layout.zig").compute_leaf_layout;
+const computeFlexboxLayout = @import("compute_flexbox_layout.zig").computeFlexboxLayout;
+const computeLeafLayout = @import("compute_leaf_layout.zig").computeLeafLayout;
 // const compute_line_breaks = @import("compute_line_breaks.zig").compute_line_breaks;
-const compute_block_layout = @import("compute_block_layout.zig").computeBlockLayout;
-const compute_text_layout = @import("./text/compute-text-layout.zig").computeTextLayout;
+const computeBlockLayout = @import("compute_block_layout.zig").computeBlockLayout;
+const computeTextLayout = @import("./text/compute-text-layout.zig").computeTextLayout;
 
 fn Measurer() fn (known_dimensions: Point(?f32), available_space: Point(AvailableSpace)) Point(f32) {
     return struct {
@@ -35,14 +35,14 @@ fn Measurer() fn (known_dimensions: Point(?f32), available_space: Point(Availabl
         }
     }.fun;
 }
-pub fn get_cached_layout(node: *Node, inputs: LayoutInput) ?LayoutOutput {
+pub fn getCachedLayout(node: *Node, inputs: LayoutInput) ?LayoutOutput {
     return node.cache.get(
         inputs.known_dimensions,
         inputs.available_space,
         inputs.run_mode,
     );
 }
-pub fn compute_child_layout(allocator: std.mem.Allocator, node_id: Node.NodeId, tree: *Tree, inputs: LayoutInput) !LayoutOutput {
+pub fn computeChildLayout(allocator: std.mem.Allocator, node_id: Node.NodeId, tree: *Tree, inputs: LayoutInput) !LayoutOutput {
     if (tree.getCache(node_id).get(
         inputs.known_dimensions,
         inputs.available_space,
@@ -56,30 +56,30 @@ pub fn compute_child_layout(allocator: std.mem.Allocator, node_id: Node.NodeId, 
         const display = style.display;
         // if (tree.getChildren(node_id).items.len == 0 and style.display.inside != .flow) {
         if (display.isInlineFlow()) {
-            break :blk try compute_text_layout(allocator, node_id, tree, inputs);
+            break :blk try computeTextLayout(allocator, node_id, tree, inputs);
         }
         if (tree.getChildren(node_id).items.len == 0) {
-            break :blk try compute_leaf_layout(inputs, node_id, tree, Measurer());
+            break :blk try computeLeafLayout(inputs, node_id, tree, Measurer());
         }
 
         // try compute_line_breaks(allocator, node);
         break :blk switch (display.outside) {
-            // .flex => try compute_flexbox_layout(allocator, node, inputs),
+            // .flex => try computeFlexboxLayout(allocator, node, inputs),
             .block => switch (display.inside) {
-                .flex => try compute_flexbox_layout(allocator, node_id, tree, inputs),
-                .flow_root => try compute_block_layout(allocator, node_id, tree, inputs),
-                .flow => try compute_block_layout(allocator, node_id, tree, inputs),
+                .flex => try computeFlexboxLayout(allocator, node_id, tree, inputs),
+                .flow_root => try computeBlockLayout(allocator, node_id, tree, inputs),
+                .flow => try computeBlockLayout(allocator, node_id, tree, inputs),
             },
             .@"inline" => switch (display.inside) {
-                .flex => try compute_flexbox_layout(allocator, node_id, tree, inputs),
-                .flow_root => try compute_block_layout(allocator, node_id, tree, inputs),
-                .flow => try compute_block_layout(allocator, node_id, tree, inputs),
+                .flex => try computeFlexboxLayout(allocator, node_id, tree, inputs),
+                .flow_root => try computeBlockLayout(allocator, node_id, tree, inputs),
+                .flow => try computeBlockLayout(allocator, node_id, tree, inputs),
             },
             .none => return error.unimplemented,
         };
         // break :blk switch (node.styles.display) {
-        //     .flex => try compute_flexbox_layout(allocator, node, inputs),
-        //     .block => try compute_block_layout(allocator, node, inputs),
+        //     .flex => try computeFlexboxLayout(allocator, node, inputs),
+        //     .block => try computeBlockLayout(allocator, node, inputs),
         //     else => return error.unimplemented,
         // };
     };
@@ -94,8 +94,8 @@ pub fn compute_child_layout(allocator: std.mem.Allocator, node_id: Node.NodeId, 
     return computed;
 }
 
-// pub fn compute_text_layout(allocator: std.mem.Allocator, node_id: Node.NodeId, tree: *Tree, inputs: LayoutInput) !LayoutOutput {
+// pub fn computeTextLayout(allocator: std.mem.Allocator, node_id: Node.NodeId, tree: *Tree, inputs: LayoutInput) !LayoutOutput {
 //     const node = tree.getNode(node_id);
-//     try compute_flexbox_layout(allocator, node_id, tree, inputs);
-//     return compute_leaf_layout(inputs, node, Measurer());
+//     try computeFlexboxLayout(allocator, node_id, tree, inputs);
+//     return computeLeafLayout(inputs, node, Measurer());
 // }

--- a/packages/core/src/layout/compute/compute_content_size_contribution.zig
+++ b/packages/core/src/layout/compute/compute_content_size_contribution.zig
@@ -1,7 +1,7 @@
 const Point = @import("../point.zig").Point;
 const styles = @import("../../styles/styles.zig");
 /// Determine how much width/height a given node contributes to it's parent's content size
-pub fn compute_content_size_contribution(
+pub fn computeContentSizeContribution(
     location: Point(f32),
     size: Point(f32),
     content_size: Point(f32),

--- a/packages/core/src/layout/compute/compute_layout.zig
+++ b/packages/core/src/layout/compute/compute_layout.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+const Tree = @import("../tree/Tree.zig").Tree;
+const Style = @import("../tree/Style.zig");
+const AvailableSpace = @import("compute_constants.zig").AvailableSpace;
+const Point = @import("../point.zig").Point;
+const computeRootLayout = @import("compute_root_layout.zig").computeRootLayout;
+const roundLayout = @import("round_layout.zig").roundLayout;
+
+pub fn computeLayout(self: *Tree, allocator: std.mem.Allocator, available_space: Point(AvailableSpace)) !void {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    var root_style: Style = .{};
+    root_style.text_decoration = .{ .line = .none };
+    root_style.font_weight = .normal;
+    root_style.font_style = .normal;
+    root_style.text_align = .left;
+    root_style.text_wrap = .wrap;
+
+    try self.computed_style_cache.computeStyle(self, 0, root_style);
+    try computeRootLayout(arena.allocator(), self, available_space);
+    roundLayout(0, self, 0);
+}

--- a/packages/core/src/layout/compute/compute_leaf_layout.zig
+++ b/packages/core/src/layout/compute/compute_leaf_layout.zig
@@ -10,7 +10,7 @@ const LayoutOutput = compute_constants.LayoutOutput;
 
 const AvailableSpace = compute_constants.AvailableSpace;
 
-pub fn compute_leaf_layout(inputs: LayoutInput, node_id: Node.NodeId, tree: *Tree, measurer: anytype) !LayoutOutput {
+pub fn computeLeafLayout(inputs: LayoutInput, node_id: Node.NodeId, tree: *Tree, measurer: anytype) !LayoutOutput {
     const known_dimensions = inputs.known_dimensions;
     const parent_size = inputs.parent_size;
     const sizing_mode = inputs.sizing_mode;

--- a/packages/core/src/layout/compute/compute_root_layout.zig
+++ b/packages/core/src/layout/compute/compute_root_layout.zig
@@ -14,11 +14,11 @@ const RequestedAxis = ComputeConstants.RequestedAxis;
 const AvailableSpace = ComputeConstants.AvailableSpace;
 const expect = std.testing.expect;
 
-const compute_child_layout = @import("compute_child_layout.zig").compute_child_layout;
+const computeChildLayout = @import("compute_child_layout.zig").computeChildLayout;
 
-pub fn compute_root_layout(allocator: std.mem.Allocator, tree: *Tree, available_space: Point(AvailableSpace)) !void {
+pub fn computeRootLayout(allocator: std.mem.Allocator, tree: *Tree, available_space: Point(AvailableSpace)) !void {
     // const root = tree.getNode(0);
-    const layout = try compute_child_layout(allocator, 0, tree, .{
+    const layout = try computeChildLayout(allocator, 0, tree, .{
         .known_dimensions = Point(?f32).NULL,
         .parent_size = .{ .x = available_space.x.intoOption(), .y = available_space.y.intoOption() },
         .run_mode = RunMode.perform_layout,

--- a/packages/core/src/layout/compute/measure_child_size.zig
+++ b/packages/core/src/layout/compute/measure_child_size.zig
@@ -6,14 +6,14 @@ const constants = @import("compute_constants.zig");
 const AvailableSpace = constants.AvailableSpace;
 const SizingMode = constants.SizingMode;
 const AbsoluteAxis = constants.AbsoluteAxis;
-const compute_child_layout = @import("compute_child_layout.zig").compute_child_layout;
+const computeChildLayout = @import("compute_child_layout.zig").computeChildLayout;
 const MeasureChildError = error{
     FailedToComputeChildLayout,
 };
 
 const std = @import("std");
 
-pub fn measure_child_size(
+pub fn measureChildSize(
     allocator: std.mem.Allocator,
     node_id: Node.NodeId,
     tree: *Tree,
@@ -24,7 +24,7 @@ pub fn measure_child_size(
     axis: AbsoluteAxis,
     vertical_margins_are_collapsible: Line(bool),
 ) MeasureChildError!f32 {
-    const child_layout = compute_child_layout(
+    const child_layout = computeChildLayout(
         allocator,
         node_id,
         tree,

--- a/packages/core/src/layout/compute/perform_child_layout.zig
+++ b/packages/core/src/layout/compute/perform_child_layout.zig
@@ -8,14 +8,14 @@ const Line = @import("../line.zig").Line;
 const compute_constants = @import("compute_constants.zig");
 const AvailableSpace = compute_constants.AvailableSpace;
 const SizingMode = compute_constants.SizingMode;
-const compute_child_layout = @import("compute_child_layout.zig").compute_child_layout;
+const computeChildLayout = @import("compute_child_layout.zig").computeChildLayout;
 
 const PerformChildLayoutError = error{
     FailedToPerformChildLayout,
     NodeNotFound,
 };
 
-pub fn perform_child_layout(
+pub fn performChildLayout(
     allocator: std.mem.Allocator,
     node_id: Node.NodeId,
     tree: *Tree,
@@ -25,7 +25,7 @@ pub fn perform_child_layout(
     sizing_mode: SizingMode,
     vertical_margins_are_collapsible: Line(bool),
 ) PerformChildLayoutError!LayoutOutput {
-    return compute_child_layout(
+    return computeChildLayout(
         allocator,
         node_id,
         tree,

--- a/packages/core/src/layout/compute/round_layout.zig
+++ b/packages/core/src/layout/compute/round_layout.zig
@@ -90,6 +90,6 @@ fn round_inner(node_id: Node.NodeId, tree: *Tree, cumulative: Point(f32), compti
     }
 }
 
-pub fn round_layout(node_id: Node.NodeId, tree: *Tree, comptime precision: f32) void {
+pub fn roundLayout(node_id: Node.NodeId, tree: *Tree, comptime precision: f32) void {
     round_inner(node_id, tree, .{ .x = 0.0, .y = 0.0 }, precision);
 }

--- a/packages/core/src/layout/compute/text/compute-text-layout.zig
+++ b/packages/core/src/layout/compute/text/compute-text-layout.zig
@@ -16,7 +16,7 @@ const TextPart = ComputedText.TextPart;
 const Maybe = @import("../../utils/Maybe.zig");
 const assert = std.debug.assert;
 const logger = std.log.scoped(.compute_text_layout);
-const perform_child_layout = @import("../perform_child_layout.zig").perform_child_layout;
+const performChildLayout = @import("../perform_child_layout.zig").performChildLayout;
 const measureUtf8 = @import("../../../uni/string-width.zig").visible.width.exclude_ansi_colors.utf8;
 
 const LineBreak = @import("../../../uni/LineBreak.zig");
@@ -391,7 +391,7 @@ fn collectText(allocator: std.mem.Allocator, parts_array: *Array(TextPart), node
     }
 
     if (!display.isInlineFlow()) {
-        const measured = try perform_child_layout(
+        const measured = try performChildLayout(
             allocator,
             node_id,
             tree,

--- a/packages/core/src/layout/tree/Tree.zig
+++ b/packages/core/src/layout/tree/Tree.zig
@@ -4,8 +4,6 @@ const std = @import("std");
 const xml = @import("../../xml.zig");
 pub const Style = @import("Style.zig");
 const Color = @import("../../colors/Color.zig");
-const compute_root_layout = @import("../compute/compute_root_layout.zig").compute_root_layout;
-const round_layout = @import("../compute/round_layout.zig").round_layout;
 const HashMap = std.AutoHashMap;
 const Layout = @import("Layout.zig");
 const Cache = @import("Cache.zig");
@@ -40,6 +38,7 @@ live_range_counter: u32 = 0,
 
 const Self = @This();
 
+usingnamespace @import("../compute/compute_layout.zig");
 pub const ROOT_NODE_ID: Node.NodeId = 0;
 pub fn init(allocator: std.mem.Allocator) !Self {
     // Initialize style system and tree together
@@ -1173,29 +1172,6 @@ pub fn invalidateStyles(self: *Self, node_id: Node.NodeId) void {
     self.markDirty(node_id);
 }
 
-pub fn computeLayout(self: *Self, allocator: std.mem.Allocator, available_space: Point(AvailableSpace)) !void {
-    // Compute the actual layout
-
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-    var root_style: Style = .{};
-    root_style.text_decoration = .{
-        .line = .none,
-    };
-    root_style.font_weight = .normal;
-    root_style.font_style = .normal;
-    root_style.text_align = .left;
-    root_style.text_wrap = .wrap;
-
-    try self.computed_style_cache.computeStyle(self, 0, root_style);
-
-    try compute_root_layout(arena.allocator(), self, available_space);
-    round_layout(0, self, 0);
-}
-
-// test "createtree" {
-//     var tree = try parseTree(std.testing.allocator,
-//         \\<div display="flex" width="20"  flex-direction="column" justify-content="center" overflow="hidden">
 //         // \\  <div display="block" width="100%" height="100%">
 //         \\    <span><div display="block" width="1" height="1"></div>Lorem ipsum dolor sit am <div display="inline-block"></div>et<div display="block" width="1" height="1"></div></span>
 //         // \\    <span>Lorem ipsum dolor sit am<span>et, cons</span>ec<span>tetur adipiscing elit. </span></span>
@@ -1212,9 +1188,7 @@ pub fn computeLayout(self: *Self, allocator: std.mem.Allocator, available_space:
 
 //     var arena = std.heap.ArenaAllocator.init(testing_allocator);
 //     defer arena.deinit();
-//     try compute_root_layout(arena.allocator(), &tree, .{ .x = .{ .definite = 100 }, .y = .{ .definite = 100 } });
 
-//     round_layout(0, &tree, 1);
 //     const layout = tree.getLayout(0);
 //     std.debug.print("\n\nlayout:\n{any}\n", .{(layout)});
 //     try tree.print(writer);


### PR DESCRIPTION
## Summary
- move `computeLayout` out of `Tree.zig`
- rename snake_case layout functions to camelCase
- update imports and exports accordingly

## Testing
- `pnpm test -r` *(fails: Connect Timeout Error)*