### PR TITLE
Fix test paths for terminfo

### DIFF
--- a/packages/core/src/cmd/terminfo/Strings.zig
+++ b/packages/core/src/cmd/terminfo/Strings.zig
@@ -610,7 +610,7 @@ const num_capabilities = @typeInfo(Capability).@"enum".fields.len;
 
 test "string capabilities" {
     const TermInfo = @import("main.zig").TermInfo;
-    var file = try std.fs.openFileAbsolute("/Applications/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty", .{});
+    var file = try std.fs.cwd().openFile("src/cmd/test-data/xterm-ghostty", .{});
 
     defer file.close();
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);

--- a/packages/core/src/cmd/terminfo/main.zig
+++ b/packages/core/src/cmd/terminfo/main.zig
@@ -228,7 +228,7 @@ test {
 }
 
 test "basic" {
-    var file = try std.fs.openFileAbsolute("/Applications/Ghostty.app/Contents/Resources/terminfo/78/xterm-ghostty", .{});
+    var file = try std.fs.cwd().openFile("src/cmd/test-data/xterm-ghostty", .{});
     defer file.close();
     const term_info = try TermInfo.initFromFile(std.testing.allocator, file);
     defer term_info.deinit();


### PR DESCRIPTION
## Summary
- fix terminfo tests to use repository test data

## Testing
- `zig build test`