### PR TITLE
Fix test filter spaces

### DIFF
--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -134,7 +134,13 @@ pub fn build(b: *std.Build) !void {
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
     _ = run_lib_unit_tests; // autofix
+
     const test_filter = b.option([]const u8, "test-filter", "Skip tests that do not match filter");
+
+    var escaped_filter: ?[]const u8 = null;
+    if (test_filter) |filter| {
+        escaped_filter = try std.mem.replaceOwned(u8, b.allocator, filter, " ", "%20");
+    }
 
     const exe_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/wasm.zig"),
@@ -143,7 +149,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
         // .filters = test_filters,
-        .filter = test_filter,
+        .filter = escaped_filter,
         .test_runner = .{
             .path = b.path("test_runner.zig"),
             .mode = .simple,

--- a/packages/core/test_runner.zig
+++ b/packages/core/test_runner.zig
@@ -260,10 +260,15 @@ const Env = struct {
     filter: ?[]const u8,
 
     fn init(allocator: Allocator) Env {
+        var filter: ?[]const u8 = null;
+        if (readEnv(allocator, "TEST_FILTER")) |rf| {
+            filter = std.mem.replaceOwned(u8, allocator, rf, "%20", " ") catch @panic("OOM");
+            allocator.free(rf);
+        }
         return .{
             .verbose = readEnvBool(allocator, "TEST_VERBOSE", true),
             .fail_first = readEnvBool(allocator, "TEST_FAIL_FIRST", false),
-            .filter = readEnv(allocator, "TEST_FILTER"),
+            .filter = filter,
         };
     }
 


### PR DESCRIPTION
## Summary
- escape `--test-filter` spaces to workaround zig bug
- unescape `TEST_FILTER` in custom test runner

## Testing
- `zig build test`