### PR TITLE
Refine layout tree debug printing

### DIFF
--- a/packages/core/src/layout/LayoutTree.zig
+++ b/packages/core/src/layout/LayoutTree.zig
@@ -20,17 +20,27 @@ pub fn deinit(self: *Self) void {
     self.nodes.deinit(self.allocator);
 }
 
-pub fn addNode(self: *Self, data: LayoutNode.Data) !LayoutNode.Id {
+pub fn createNode(self: *Self, data: LayoutNode.Data) !LayoutNode.Id {
     const id = self.node_count;
     try self.nodes.put(self.allocator, id, LayoutNode{ .id = id, .data = data });
     self.node_count += 1;
     return id;
 }
-pub fn addTextNode(self: *Self, contents: []const u8) !LayoutNode.Id {
-    const node_id = try self.addNode(.{ .text_node = .{} });
+pub fn createTextNode(self: *Self, contents: []const u8) !LayoutNode.Id {
+    const node_id = try self.createNode(.{ .text_node = .{} });
     var node = self.getNodePtr(node_id);
     try node.data.text_node.contents.appendSlice(self.allocator, contents);
     return node_id;
+}
+pub fn appendNode(self: *Self, parent_id: LayoutNode.Id, child_id: LayoutNode.Id) !void {
+    const parent = self.getNodePtr(parent_id);
+    var list: *Array(LayoutNode.Id) = switch (parent.data) {
+        .inline_node => |*n| &n.children,
+        .block_container_node => |*n| &n.children,
+        .inline_container_node => |*n| &n.children,
+        else => return error.InvalidParent,
+    };
+    try list.append(self.allocator, child_id);
 }
 pub fn getNodePtr(self: *Self, id: LayoutNode.Id) *LayoutNode {
     return self.nodes.getPtr(id) orelse std.debug.panic("LayoutTree: Node {d} not found", .{id});
@@ -112,11 +122,80 @@ pub const LineBox = struct {
     }
 };
 
+fn writeDocRef(writer: std.io.AnyWriter, ref: DocRef) !void {
+    switch (ref) {
+        .anonymous => try writer.writeAll("anon"),
+        .doc_node => |id| try writer.print("doc #{d}", .{id}),
+    }
+}
+
+fn getChildren(node: *LayoutNode) []const LayoutNode.Id {
+    return switch (node.data) {
+        .inline_node => |*n| n.children.items,
+        .block_container_node => |*n| n.children.items,
+        .inline_container_node => |*n| n.children.items,
+        else => &[_]LayoutNode.Id{},
+    };
+}
+
+fn printNodeInternal(self: *Self, node_id: LayoutNode.Id, writer: std.io.AnyWriter, prefix: []const u8, is_root: bool, is_last: bool) !void {
+    const node = self.getNodePtr(node_id);
+
+    if (!is_root) {
+        try writer.writeAll(prefix);
+        if (is_last)
+            try writer.writeAll("└── ")
+        else
+            try writer.writeAll("├── ");
+    }
+
+    switch (node.data) {
+        .text_node => |text| {
+            if (is_root) {
+                // root has no prefix
+            }
+            try writer.print("[{s} #{d}] \"{s}\"", .{ @tagName(node.data), node.id, text.contents.items });
+        },
+        .inline_node => |inline_node| {
+            try writer.print("[{s} #{d} atomic={s} ref=", .{ @tagName(node.data), node.id, if (inline_node.is_atomic) "true" else "false" });
+            try writeDocRef(writer, inline_node.ref);
+            try writer.print(" children={d}]", .{inline_node.children.items.len});
+        },
+        .block_container_node => |block| {
+            try writer.print("[{s} #{d} ref=", .{ @tagName(node.data), node.id });
+            try writeDocRef(writer, block.ref);
+            try writer.print(" children={d}]", .{block.children.items.len});
+        },
+        .inline_container_node => |container| {
+            try writer.print("[{s} #{d} ref=", .{ @tagName(node.data), node.id });
+            try writeDocRef(writer, container.ref);
+            try writer.print(" children={d} lines={d}]", .{ container.children.items.len, container.line_boxes.items.len });
+        },
+    }
+
+    try writer.writeByte('\n');
+
+    var new_prefix_buf: [256]u8 = undefined;
+    var new_prefix_len: usize = 0;
+    if (!is_root) {
+        std.mem.copyForwards(u8, new_prefix_buf[0..prefix.len], prefix);
+        const segment = if (is_last) "    " else "│   ";
+        new_prefix_len = prefix.len + segment.len;
+        std.mem.copyForwards(u8, new_prefix_buf[prefix.len .. prefix.len + segment.len], segment);
+    } else {
+        new_prefix_len = 0;
+    }
+    const new_prefix = new_prefix_buf[0..new_prefix_len];
+
+    const children = getChildren(node);
+    for (children, 0..) |child, idx| {
+        const last_child = idx == children.len - 1;
+        try self.printNodeInternal(child, writer, new_prefix, false, last_child);
+    }
+}
+
 pub fn printNode(self: *Self, node_id: LayoutNode.Id, writer: std.io.AnyWriter) !void {
-    _ = self; // autofix
-    _ = node_id; // autofix
-    _ = writer; // autofix
-    // TODO: Implement
+    try self.printNodeInternal(node_id, writer, "", true, true);
 }
 pub fn printRoot(self: *Self, writer: std.io.AnyWriter) !void {
     try self.printNode(0, writer);
@@ -125,12 +204,35 @@ pub fn printRoot(self: *Self, writer: std.io.AnyWriter) !void {
 test "LayoutTree" {
     var tree = Self.init(std.testing.allocator);
     defer tree.deinit();
-    const id = try tree.addTextNode("Hello World");
-    try std.testing.expectEqual(id, 0);
+
+    const root = try tree.createNode(.{ .block_container_node = .{ .ref = .anonymous } });
+    try std.testing.expectEqual(root, 0);
+
+    const container = try tree.createNode(.{ .inline_container_node = .{ .ref = .anonymous } });
+    const inline_node_id = try tree.createNode(.{ .inline_node = .{ .ref = .anonymous, .is_atomic = false } });
+    const text1 = try tree.createTextNode("abc");
+    const text2 = try tree.createTextNode("def");
+    const text3 = try tree.createTextNode("zzz");
+
+    try tree.appendNode(root, container);
+    try tree.appendNode(root, text3);
+    try tree.appendNode(container, inline_node_id);
+    try tree.appendNode(inline_node_id, text1);
+    try tree.appendNode(inline_node_id, text2);
+
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
     const writer = buf.writer().any();
     try tree.printRoot(writer);
 
-    try std.testing.expectEqualStrings(buf.items, "");
+    const expected =
+        \\[block_container_node #0 ref=anon children=2]
+        \\├── [inline_container_node #1 ref=anon children=1 lines=0]
+        \\│   └── [inline_node #2 atomic=false ref=anon children=2]
+        \\│       ├── [text_node #3] "abc"
+        \\│       └── [text_node #4] "def"
+        \\└── [text_node #5] "zzz"
+        \\
+    ;
+    try std.testing.expectEqualStrings(buf.items, expected);
 }


### PR DESCRIPTION
## Summary
- rename `addNode`/`addTextNode` to `createNode`/`createTextNode`
- add `appendNode` for attaching children
- compute prefix length using the copied segment length
- update `LayoutTree` test to build deeper tree and use multiline strings

## Testing
- `zig fmt packages/core/src/layout/LayoutTree.zig`
- `NO_COLOR=1 zig build test`