### PR TITLE
Add snapshot testing helper in core

### DIFF
--- a/packages/core/build.zig
+++ b/packages/core/build.zig
@@ -65,6 +65,7 @@ pub fn build(b: *std.Build) !void {
     }
 
     const test_filter = b.option([]const u8, "test-filter", "Skip tests that do not match filter");
+    const update_snapshots = b.option(bool, "update-snapshots", "Regenerate snapshot files");
 
     const exe_unit_tests = b.addTest(.{
         .root_source_file = b.path("src/wasm.zig"),
@@ -82,6 +83,9 @@ pub fn build(b: *std.Build) !void {
     const install_step = b.addInstallArtifact(exe_unit_tests, .{});
 
     const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
+    if (update_snapshots orelse false) {
+        run_exe_unit_tests.setEnvironmentVariable("UPDATE_SNAPSHOTS", "true");
+    }
 
     // Expose steps for running and debugging tests
     const test_step = b.step("test", "Run unit tests");

--- a/packages/core/src/testing/__snapshots__/basic_snapshot.snap
+++ b/packages/core/src/testing/__snapshots__/basic_snapshot.snap
@@ -1,0 +1,1 @@
+hello snapshot

--- a/packages/core/src/testing/snapshot.zig
+++ b/packages/core/src/testing/snapshot.zig
@@ -1,0 +1,89 @@
+const std = @import("std");
+
+pub inline fn expectMatchSnapshot(
+    allocator: std.mem.Allocator,
+    description: []const u8,
+    actual: []const u8,
+) !void {
+    return expectMatchSnapshotImpl(allocator, description, actual, @src());
+}
+
+fn expectMatchSnapshotImpl(
+    allocator: std.mem.Allocator,
+    description: []const u8,
+    actual: []const u8,
+    comptime loc: std.builtin.SourceLocation,
+) !void {
+    const sanitized = try sanitizeDescription(allocator, description);
+    defer allocator.free(sanitized);
+
+    var file_path: []const u8 = loc.file;
+    const allocated_path = if (!std.mem.startsWith(u8, file_path, "src/")) blk: {
+        file_path = try std.fs.path.join(allocator, &.{ "src", file_path });
+        break :blk true;
+    } else false;
+    defer if (allocated_path) allocator.free(file_path);
+
+    const test_dir = std.fs.path.dirname(file_path) orelse ".";
+    const snapshot_dir = try std.fs.path.join(allocator, &.{ test_dir, "__snapshots__" });
+    defer allocator.free(snapshot_dir);
+    const snapshot_path = try std.fs.path.join(allocator, &.{ snapshot_dir, sanitized });
+    defer allocator.free(snapshot_path);
+
+    var update = false;
+    if (std.process.getEnvVarOwned(allocator, "UPDATE_SNAPSHOTS")) |val| {
+        update = std.ascii.eqlIgnoreCase(val, "true");
+        allocator.free(val);
+    } else |err| {
+        if (err != error.EnvironmentVariableNotFound) return err;
+    }
+
+    var file = std.fs.cwd().openFile(snapshot_path, .{ .mode = .read_only }) catch |err| {
+        if (err == error.FileNotFound) {
+            update = true;
+            return writeSnapshot(snapshot_path, actual);
+        } else {
+            return err;
+        }
+    };
+    defer file.close();
+
+    if (update) {
+        return writeSnapshot(snapshot_path, actual);
+    }
+
+    const stat = try file.stat();
+    const buf = try allocator.alloc(u8, stat.size);
+    defer allocator.free(buf);
+    _ = try file.readAll(buf);
+
+    if (!std.mem.eql(u8, buf, actual)) {
+        std.debug.print("Snapshot mismatch for {s}\n", .{snapshot_path});
+    }
+    try std.testing.expectEqualStrings(buf, actual);
+}
+
+fn writeSnapshot(path: []const u8, data: []const u8) !void {
+    const dir = std.fs.path.dirname(path) orelse ".";
+    std.fs.cwd().makePath(dir) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+    var file = try std.fs.cwd().createFile(path, .{ .truncate = true });
+    defer file.close();
+    try file.writeAll(data);
+}
+
+fn sanitizeDescription(allocator: std.mem.Allocator, desc: []const u8) ![]u8 {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+    for (desc) |c| {
+        if (std.ascii.isAlphanumeric(c) or c == '-' or c == '_') {
+            try buf.append(c);
+        } else {
+            try buf.append('_');
+        }
+    }
+    try buf.appendSlice(".snap");
+    return buf.toOwnedSlice();
+}

--- a/packages/core/src/testing/snapshot_test.zig
+++ b/packages/core/src/testing/snapshot_test.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const snapshot = @import("snapshot.zig");
+
+test "expectMatchSnapshot basic" {
+    const allocator = std.testing.allocator;
+    const content = "hello snapshot";
+    try snapshot.expectMatchSnapshot(allocator, "basic snapshot", content);
+}

--- a/packages/core/src/wasm.zig
+++ b/packages/core/src/wasm.zig
@@ -586,4 +586,5 @@ test {
     _ = @import("./uni/LineBreakStream.zig");
     _ = @import("./layout/v2/text/white-space-processor.zig");
     _ = @import("./layout/v2/text/LinesBuilder.zig");
+    _ = @import("./testing/snapshot_test.zig");
 }


### PR DESCRIPTION
## Summary
- add `expectMatchSnapshot` snapshot utility
- store snapshots next to test files
- support snapshot updates via `-Dupdate-snapshots`

## Testing
- `zig build test`
