### PR TITLE
Port layout cache to v2 tree

### DIFF
--- a/packages/core/src/layout/v2/Cache.zig
+++ b/packages/core/src/layout/v2/Cache.zig
@@ -1,0 +1,122 @@
+const mod = @import("mod.zig");
+const LayoutResult = mod.LayoutResult;
+const RunMode = mod.ContainerContext.RunMode;
+const AvailableSpace = mod.constants.AvailableSpace;
+const Point = @import("../point.zig").Point;
+
+const Cache = @This();
+
+fn CacheEntry(comptime T: type) type {
+    return struct {
+        known_dimensions: Point(?f32),
+        available_space: Point(AvailableSpace),
+        content: T,
+    };
+}
+
+const CACHE_SIZE: usize = 9;
+final_layout_entry: ?CacheEntry(LayoutResult) = null,
+measure_entries: [CACHE_SIZE]?CacheEntry(Point(f32)) = [_]?CacheEntry(Point(f32)){null} ** CACHE_SIZE,
+
+pub fn computeCacheSlot(known_dimensions: Point(?f32), available_space: Point(AvailableSpace)) usize {
+    const has_known_width = known_dimensions.x != null;
+    const has_known_height = known_dimensions.y != null;
+    if (has_known_width and has_known_height) {
+        return 0;
+    }
+    if (has_known_width and !has_known_height) {
+        if (available_space.y == .min_content) {
+            return 2;
+        }
+        return 1;
+    }
+    if (has_known_height and !has_known_width) {
+        if (available_space.x == .min_content) {
+            return 4;
+        }
+        return 3;
+    }
+    switch (available_space.x) {
+        .max_content, .definite => {
+            switch (available_space.y) {
+                .max_content, .definite => return 5,
+                .min_content => return 6,
+            }
+        },
+        .min_content => {
+            switch (available_space.y) {
+                .max_content, .definite => return 7,
+                .min_content => return 8,
+            }
+        },
+    }
+}
+
+pub fn get(self: *Cache, known_dimensions: Point(?f32), available_space: Point(AvailableSpace), run_mode: RunMode) ?LayoutResult {
+    switch (run_mode) {
+        .perform_layout => {
+            const entry = self.final_layout_entry orelse return null;
+            const cached_size = entry.content.size;
+            if ((known_dimensions.x == entry.known_dimensions.x or known_dimensions.x == cached_size.x) and
+                (known_dimensions.y == entry.known_dimensions.y or known_dimensions.y == cached_size.y) and
+                (known_dimensions.x != null or entry.available_space.x.isRoughlyEqual(available_space.x)) and
+                (known_dimensions.y != null or entry.available_space.y.isRoughlyEqual(available_space.y)))
+            {
+                return entry.content;
+            }
+            return null;
+        },
+        .compute_size => {
+            for (self.measure_entries) |entry_option| {
+                const entry = entry_option orelse continue;
+                const cached_size = entry.content;
+                if ((known_dimensions.x == entry.known_dimensions.x or known_dimensions.x == cached_size.x) and
+                    (known_dimensions.y == entry.known_dimensions.y or known_dimensions.y == cached_size.y) and
+                    (known_dimensions.x != null or entry.available_space.x.isRoughlyEqual(available_space.x)) and
+                    (known_dimensions.y != null or entry.available_space.y.isRoughlyEqual(available_space.y)))
+                {
+                    return LayoutResult{ .size = cached_size }; // other fields default zero
+                }
+            }
+            return null;
+        },
+    }
+}
+
+pub fn store(self: *Cache, known_dimensions: Point(?f32), available_space: Point(AvailableSpace), run_mode: RunMode, layout_output: LayoutResult) void {
+    switch (run_mode) {
+        .perform_layout => {
+            self.final_layout_entry = .{
+                .known_dimensions = known_dimensions,
+                .available_space = available_space,
+                .content = layout_output,
+            };
+        },
+        .compute_size => {
+            const cache_slot = computeCacheSlot(known_dimensions, available_space);
+            self.measure_entries[cache_slot] = .{
+                .known_dimensions = known_dimensions,
+                .available_space = available_space,
+                .content = layout_output.size,
+            };
+        },
+    }
+}
+
+pub fn clear(self: *Cache) void {
+    self.final_layout_entry = null;
+    self.measure_entries = [_]?CacheEntry(Point(f32)){null} ** CACHE_SIZE;
+}
+
+pub fn isEmpty(self: *Cache) bool {
+    if (self.final_layout_entry != null) {
+        return false;
+    }
+    for (self.measure_entries) |entry| {
+        if (entry != null) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/packages/core/src/layout/v2/LayoutTree.zig
+++ b/packages/core/src/layout/v2/LayoutTree.zig
@@ -4,6 +4,7 @@ const DocTree = @import("../../tree/Tree.zig");
 const Array = std.ArrayListUnmanaged;
 const HashMap = std.AutoHashMapUnmanaged;
 const mod = @import("mod.zig");
+const Cache = @import("Cache.zig");
 
 const docFromXml = @import("./doc-from-xml.zig").docFromXml;
 
@@ -56,12 +57,17 @@ pub fn getNodePtr(self: *Self, id: LayoutNode.Id) *LayoutNode {
     return self.nodes.getPtr(id) orelse std.debug.panic("LayoutTree: Node {d} not found", .{id});
 }
 
+pub inline fn getCache(self: *Self, id: LayoutNode.Id) *Cache {
+    return &self.getNodePtr(id).cache;
+}
+
 pub const LayoutNode = struct {
     id: Id,
     ref: DocRef,
     parent: ?Id = null,
     data: Data,
     box: mod.Box = .{},
+    cache: Cache = .{},
     pub const Id = u32;
     pub const Data = union(enum) {
         text_node: TextNode,

--- a/packages/core/src/layout/v2/computeChildLayout.zig
+++ b/packages/core/src/layout/v2/computeChildLayout.zig
@@ -3,17 +3,26 @@ const LayoutContext = mod.LayoutContext;
 const css_types = @import("../../css/types.zig");
 
 pub fn computeChildLayout(context: *LayoutContext, inputs: mod.ContainerContext, l_node_id: mod.LayoutNode.Id) mod.ComputeLayoutError!mod.LayoutResult {
+    const cache = context.layout_tree.getCache(l_node_id);
+    if (cache.get(inputs.known_dimensions, inputs.available_space, inputs.run_mode)) |cached| {
+        return cached;
+    }
+
     const l_node = context.layout_tree.getNodePtr(l_node_id);
-    return switch (l_node.data) {
-        .block_container_node => {
-            const display = context.getStyleValue(css_types.Display, l_node_id, .display);
-            switch (display.inside) {
-                .flow_root => return mod.computeBlockLayout(context, inputs, l_node_id),
-                .flex => return mod.computeFlexboxLayout(context, inputs, l_node_id),
-                .flow => return mod.computeBlockLayout(context, inputs, l_node_id), // fallback to block layout
-            }
-        },
-        .inline_container_node => mod.computeInlineContextLayout(context, inputs, l_node_id),
-        else => @panic("unimplemented"),
+    const computed: mod.LayoutResult = blk: {
+        switch (l_node.data) {
+            .block_container_node => {
+                const display = context.getStyleValue(css_types.Display, l_node_id, .display);
+                break :blk switch (display.inside) {
+                    .flow_root => try mod.computeBlockLayout(context, inputs, l_node_id),
+                    .flex => try mod.computeFlexboxLayout(context, inputs, l_node_id),
+                    .flow => try mod.computeBlockLayout(context, inputs, l_node_id), // fallback to block layout
+                };
+            },
+            .inline_container_node => break :blk try mod.computeInlineContextLayout(context, inputs, l_node_id),
+            else => @panic("unimplemented"),
+        }
     };
+    cache.store(inputs.known_dimensions, inputs.available_space, inputs.run_mode, computed);
+    return computed;
 }


### PR DESCRIPTION
## Summary
- implement `Cache` for layout v2 engine
- store cache on `LayoutTree.LayoutNode`
- provide `getCache` accessor
- use the cache in `computeChildLayout`

## Testing
- `zig build test`